### PR TITLE
🚀  3.0 Implement GET `/rate?from={from}&to={to}` endpoint in `rate-service`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# application configuration
+application.yml

--- a/rate-service/src/main/java/com/example/rateservice/config/ExchangeRateApiConfig.java
+++ b/rate-service/src/main/java/com/example/rateservice/config/ExchangeRateApiConfig.java
@@ -1,32 +1,23 @@
 package com.example.rateservice.config;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 @Component
 @ConfigurationProperties(prefix = "exchange-rate.api")
 public class ExchangeRateApiConfig {
-  @Value("${exchange-rate.api.key}")
-  private String apiKey;
-
-  @Value("${exchange-rate.api.url}")
-  private String apiUrl;
-
-  @Value("${exchange-rate.api.endpoint:/pair}")
-  private String apiEndpoint;
 
   private String key;
   private String url;
   private String endpoint = "/pair";
 
-  // Getters and setters (required)
+  // Getters and setters
   public String getKey() {
     return key;
   }
 
   public void setKey(String key) {
-    this.key = apiKey;
+    this.key = key;
   }
 
   public String getUrl() {
@@ -34,7 +25,7 @@ public class ExchangeRateApiConfig {
   }
 
   public void setUrl(String url) {
-    this.url = apiUrl;
+    this.url = url;
   }
 
   public String getEndpoint() {

--- a/rate-service/src/main/java/com/example/rateservice/config/ExchangeRateApiConfig.java
+++ b/rate-service/src/main/java/com/example/rateservice/config/ExchangeRateApiConfig.java
@@ -1,0 +1,47 @@
+package com.example.rateservice.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "exchange-rate.api")
+public class ExchangeRateApiConfig {
+  @Value("${exchange-rate.api.key}")
+  private String apiKey;
+
+  @Value("${exchange-rate.api.url}")
+  private String apiUrl;
+
+  @Value("${exchange-rate.api.endpoint:/pair}")
+  private String apiEndpoint;
+
+  private String key;
+  private String url;
+  private String endpoint = "/pair";
+
+  // Getters and setters (required)
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = apiKey;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = apiUrl;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
+  }
+}

--- a/rate-service/src/main/java/com/example/rateservice/controller/RateController.java
+++ b/rate-service/src/main/java/com/example/rateservice/controller/RateController.java
@@ -1,0 +1,25 @@
+package com.example.rateservice.controller;
+
+import com.example.rateservice.service.RateService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.*;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/rate")
+public class RateController {
+
+  private static final Logger logger = LoggerFactory.getLogger(RateController.class);
+  private final RateService rateService;
+
+  public RateController(RateService rateService) {
+    this.rateService = rateService;
+  }
+
+  @GetMapping
+  public Map<String, Object> getExchangeRate(@RequestParam String from, @RequestParam String to) {
+    logger.info("Request received for exchange rate from {} to {}", from, to);
+    return rateService.fetchRate(from.toUpperCase(), to.toUpperCase());
+  }
+}

--- a/rate-service/src/main/java/com/example/rateservice/service/RateService.java
+++ b/rate-service/src/main/java/com/example/rateservice/service/RateService.java
@@ -1,0 +1,52 @@
+package com.example.rateservice.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.example.rateservice.config.ExchangeRateApiConfig;
+
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.util.Map;
+
+@Service
+public class RateService {
+  private final ExchangeRateApiConfig apiConfig;
+
+  public RateService(ExchangeRateApiConfig apiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  private static final Logger logger = LoggerFactory.getLogger(RateService.class);
+
+  @SuppressWarnings("unchecked")
+  public Map<String, Object> fetchRate(String from, String to) {
+    try {
+      String url = String.format("%s/%s%s/%s/%s",
+          apiConfig.getUrl(), apiConfig.getKey(), apiConfig.getEndpoint(), from, to);
+      RestTemplate restTemplate = new RestTemplate();
+      Map<String, Object> response = (Map<String, Object>) restTemplate.getForObject(url, Map.class);
+
+      // Validate response
+      if (response == null || !"success".equals(response.get("result"))) {
+        throw new RuntimeException("Invalid API response: " + response);
+      }
+
+      // Extract the conversion rate
+      double rate = (double) response.get("conversion_rate");
+      return Map.of(
+          "from", from,
+          "to", to,
+          "rate", rate);
+
+    } catch (HttpClientErrorException e) {
+      logger.error("API error: {}", e.getMessage());
+      throw new RuntimeException("Currency not supported: " + from + " or " + to);
+    } catch (Exception e) {
+      logger.error("Unexpected error: {}", e.getMessage());
+      throw new RuntimeException("Failed to retrieve exchange rate. Reason: " + e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
### 🚀 PR: Implement GET `/rate?from={from}&to={to}` endpoint in `rate-service`

Closes #3

This PR adds a new REST endpoint in the `rate-service` to retrieve exchange rates between two currencies via the ExchangeRate-API.

---

### ✅ Changes Introduced

* **New endpoint:**
  `GET /rate?from={from}&to={to}`
  Example: `/rate?from=USD&to=EUR`

* **Added files & logic:**

  * `RateController.java`: Handles `/rate` requests.
  * `RateService.java`: Fetches data from ExchangeRate-API and parses it.
  * `ExchangeRateApiConfig.java`: Configures API key, base URL, and endpoint using `application.yml`.

* **Error Handling:**
  Handles unsupported or invalid currency codes with appropriate error messages.

---

### 🛠 Configuration

Added `.gitignore` entry for `application.yml` and used it for storing sensitive API values:

```yaml
# application.yml
exchange-rate:
  api:
    key: API_KEY
    url: API_URL
    endpoint: /pair
```

---

### 🧪 Example Call

```bash
curl "http://localhost:8080/rate?from=usd&to=eur"
```

Expected:

```json
{
  "to": "EUR",
  "from": "USD",
  "rate": 0.85
}
```

---

### 📓 Notes

* Input parameters are normalized to uppercase.
* API failures are logged and wrapped with meaningful runtime exceptions.

